### PR TITLE
bug(BDSGOLD-900): Fix /opt/alti-spark-2.3.2 dir due to changes in RPM for CentOS8

### DIFF
--- a/sap-xmake-build.sh
+++ b/sap-xmake-build.sh
@@ -162,7 +162,7 @@ echo "Packaging spark example rpm with name ${RPM_NAME} with version ${SPARK_VER
 ##########################
 # Spark EXAMPLE RPM #
 ##########################
-export RPM_BUILD_DIR=${INSTALL_DIR}/opt/alti-spark-${SPARK_VERSION}/test_spark
+export RPM_BUILD_DIR=${INSTALL_DIR}/tmp/alti-spark-${SPARK_VERSION}/test_spark
 echo "RPM_BUILD_DIR: ${RPM_BUILD_DIR}"
 
 # Generate RPM based on where spark artifacts are placed from previous steps
@@ -175,7 +175,7 @@ mkdir --mode=0755 -p "${RPM_BUILD_DIR}"
 echo "cp -rp target/*.jar $RPM_BUILD_DIR/"
 cp -rp target/*.jar $RPM_BUILD_DIR/
 
-echo "cp -rp * $RPM_BUILD_DIR/"
+echo "cp -rp target/* $RPM_BUILD_DIR/"
 cp -rp * $RPM_BUILD_DIR/
 rm -rf $RPM_BUILD_DIR/localbuild.sh
 rm -rf $RPM_BUILD_DIR/*.log
@@ -209,7 +209,7 @@ fpm --verbose \
 --template-value pkgname=$RPM_EXAMPLE_NAME \
 --rpm-auto-add-directories \
 -C ${INSTALL_DIR} \
-opt
+tmp/alti-spark-$SPARK_VERSION/test_spark=/opt/alti-spark-2.3.2/
 
 echo "Finished packaging spark example rpm"
 


### PR DESCRIPTION
Tested manually on CentOS 8. Conflicts on dir `/opt/alti-spark-2.3.2` no longer appears.

```
[root@43cf3684d59a tmp]# dnf install alti-spark-2.3.2
Last metadata expiration check: 6:31:53 ago on Wed 10 Jun 2020 06:59:03 PM UTC.
Dependencies resolved.
==============================================================================================================================================================
 Package                               Architecture                Version                                        Repository                             Size
==============================================================================================================================================================
Installing:
 alti-spark-2.3.2                      noarch                      1:2.3.2-20200608145200                         verticloud-prod8                      203 M

Transaction Summary
==============================================================================================================================================================
Install  1 Package

Total download size: 203 M
Installed size: 236 M
Is this ok [y/N]: y
Downloading Packages:
...
sap-alti-spark-2.3.2-20200608145200.noarch.rpm                                                                                5.4 MB/s | 203 MB     00:37    
--------------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                         5.4 MB/s | 203 MB     00:37     
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                      1/1 
  Installing       : alti-spark-2.3.2-1:2.3.2-20200608145200.noarch                                                                                       1/1 
  Verifying        : alti-spark-2.3.2-1:2.3.2-20200608145200.noarch                                                                                       1/1 

Installed:
  alti-spark-2.3.2-1:2.3.2-20200608145200.noarch                                                                                                              

Complete!
[root@43cf3684d59a tmp]# dnf localinstall alti-spark-2.3.2-example.rpm
Last metadata expiration check: 6:34:46 ago on Wed 10 Jun 2020 06:59:03 PM UTC.
Dependencies resolved.
==============================================================================================================================================================
 Package                                      Architecture               Version                                       Repository                        Size
==============================================================================================================================================================
Installing:
 alti-spark-2.3.2-example                     noarch                     1:2.3.2-20200611002952                        @commandline                     186 k

Transaction Summary
==============================================================================================================================================================
Install  1 Package

Total size: 186 k
Installed size: 433 k
Is this ok [y/N]: y
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                      1/1 
  Installing       : alti-spark-2.3.2-example-1:2.3.2-20200611002952.noarch                                                                               1/1 
  Verifying        : alti-spark-2.3.2-example-1:2.3.2-20200611002952.noarch                                                                               1/1 

Installed:
  alti-spark-2.3.2-example-1:2.3.2-20200611002952.noarch                                                                                                      

Complete!
[root@43cf3684d59a tmp]# 

```